### PR TITLE
Modified main.tf to use data.tf for AMI lookup

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,9 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 resource "aws_instance" "this" {
-  ami                         = "ami-06b263d6ceff0b3dd"
+  ami                         = data.aws_ami.ubuntu.id
   instance_type               = "t2.micro"
   subnet_id                   = var.subnet_id
   iam_instance_profile        = var.iam_instance_profile


### PR DESCRIPTION
Data blocks are useful for AMI lookups in case the AMI id changes which could be caused by numerous changes to the AMI including a new version. 

The data block looks up the Ubuntu version that was specified in the AMI ID but always gets the latest value and different AMIs can be retrieved by modifying the filter conditions. 